### PR TITLE
Eliminate "Use of qw(...) as parentheses is deprecated" warnings.

### DIFF
--- a/lib/XML/RSS/LibXML.pm
+++ b/lib/XML/RSS/LibXML.pm
@@ -41,7 +41,7 @@ sub new
 
 {
     # Proxy methods
-    foreach my $method qw(reset channel image add_item textinput skipDays skipHours) {
+    foreach my $method (qw(reset channel image add_item textinput skipDays skipHours)) {
         no strict 'refs';
         *{$method} = sub { my $self = shift; $self->impl->$method($self, @_) };
     }

--- a/lib/XML/RSS/LibXML/V0_9.pm
+++ b/lib/XML/RSS/LibXML/V0_9.pm
@@ -139,7 +139,7 @@ sub parse_channel
 
     my ($root) = $xc->findnodes('/rdf:RDF/rss09:channel', $dom);
     my %h = $self->parse_children($c, $root);
-    foreach my $field qw(textinput image) {
+    foreach my $field (qw(textinput image)) {
         delete $h{$field};
 #        if (my $v = $h{$field}) {
 #            $c->$field(UNIVERSAL::isa($v, 'XML::RSS::LibXML::MagicElement') ? $v : %$v);
@@ -274,7 +274,7 @@ sub create_channel
     $root->appendChild($channel);
 
     my $node;
-    foreach my $p qw(title link description) {
+    foreach my $p (qw(title link description)) {
         my $text = $c->{channel}{$p};
         next unless defined $text;
         $node = $dom->createElement($p);
@@ -305,7 +305,7 @@ sub create_item
 
     my $item = $dom->createElement('item');
     my $node;
-    foreach my $e qw(title link) {
+    foreach my $e (qw(title link)) {
         $node = $dom->createElement($e);
         $node->appendText($i->{$e});
         $item->addChild($node);

--- a/lib/XML/RSS/LibXML/V0_91.pm
+++ b/lib/XML/RSS/LibXML/V0_91.pm
@@ -169,7 +169,7 @@ sub parse_channel
     my ($root) = $xc->findnodes('/rss/channel', $dom);
     my %h = $self->parse_children($c, $root);
 
-    foreach my $type qw(day hour) {
+    foreach my $type (qw(day hour)) {
         my $field = 'skip' . ucfirst($type) . 's';
         if (my $skip = delete $h{$field}) {
             $c->$field(%$skip);
@@ -248,7 +248,7 @@ sub create_channel
         }
     }
 
-    foreach my $type qw(day hour) {
+    foreach my $type (qw(day hour)) {
         my $field = 'skip' . ucfirst($type) . 's';
         my $skip = $c->$field;
         if ($skip && defined $skip->{$type}) {

--- a/lib/XML/RSS/LibXML/V2_0.pm
+++ b/lib/XML/RSS/LibXML/V2_0.pm
@@ -141,7 +141,7 @@ sub parse_channel
     my ($root) = $xc->findnodes('/rss/channel', $dom);
     my %h = $self->parse_children($c, $root, './*[name() != "item"]');
 
-    foreach my $type qw(day hour) {
+    foreach my $type (qw(day hour)) {
         my $field = 'skip' . ucfirst($type) . 's';
         if (my $skip = delete $h{$field}) {
             if (ref $skip ne 'HASH') {
@@ -152,7 +152,7 @@ sub parse_channel
         }
     }
 
-    foreach my $field qw(textinput image) {
+    foreach my $field (qw(textinput image)) {
         if (my $v = $h{$field}) {
             if (ref $v ne 'HASH') {
 #                warn "field $field has invalid entry (does this RSS validate?)";
@@ -249,7 +249,7 @@ sub create_channel
 
     $self->create_element_from_spec($c->channel, $dom, $channel, \%ChannelElements);
 
-    foreach my $type qw(day hour) {
+    foreach my $type (qw(day hour)) {
         my $field = 'skip' . ucfirst($type) . 's';
         my $skip = $c->$field;
         if ($skip && defined $skip->{$type}) {

--- a/t/items-are-0.t
+++ b/t/items-are-0.t
@@ -405,7 +405,7 @@ sub match_elements
 }
 
 {
-    foreach my $version qw(0.9 0.91 1.0 2.0) {
+    foreach my $version (qw(0.9 0.91 1.0 2.0)) {
         my $rss = create_rss_1({version => $version});
         # TEST
         match_elements($rss, 'image', { url => 0, link => "http://freshmeat.net/", title => "freshmeat.net" });
@@ -413,7 +413,7 @@ sub match_elements
 }
 
 {
-    foreach my $version qw(0.9 0.91 1.0 2.0) {
+    foreach my $version (qw(0.9 0.91 1.0 2.0)) {
         my $rss = create_rss_1({version => $version, image_link => "0",});
         # TEST
         match_elements($rss, 'image', { url => 0, link => 0, title => "freshmeat.net" });
@@ -421,7 +421,7 @@ sub match_elements
 }
 
 {
-    foreach my $version qw(0.91 2.0) {
+    foreach my $version (qw(0.91 2.0)) {
         my $rss = create_rss_1({
                 version => $version, 
                 image_params => [width => 0, height => 0, description => 0],
@@ -554,7 +554,7 @@ SKIP:
 }
 
 {
-    foreach my $version qw(0.9 0.91 2.0) {
+    foreach my $version (qw(0.9 0.91 2.0)) {
         my $rss = create_no_image_rss({version => $version});
         # TEST
         not_contains($rss, "<textinput>",
@@ -564,7 +564,7 @@ SKIP:
 }
 
 {
-    foreach my $version qw(0.9 0.91) {
+    foreach my $version (qw(0.9 0.91)) {
         my $rss = create_textinput_with_0_rss({version => $version});
         # TEST
         match_elements($rss, 'textinput', { title => 0, description => 0, name => 0, link => 0 });

--- a/t/regress-content-encoded.t
+++ b/t/regress-content-encoded.t
@@ -2,7 +2,7 @@ use strict;
 use Test::More (tests => 2);
 use XML::RSS::LibXML;
 
-for my $version qw(1.0 2.0) {
+for my $version (qw(1.0 2.0)) {
     my $rss = XML::RSS::LibXML->new(version => "2.0");
     $rss->add_module(prefix => "content",
         uri => "http://purl.org/rss/1.0/modules/content/"


### PR DESCRIPTION
Subject says it all. Deprecated in 5.14.0.
