### PR TITLE
Permit namespace prefixes with initial uppercase

### DIFF
--- a/lib/XML/RSS/LibXML.pm
+++ b/lib/XML/RSS/LibXML.pm
@@ -89,7 +89,7 @@ sub add_module
     if ($args{prefix} eq '#default') {
         # no op
     } else {
-        $args{prefix} =~ /^[a-z_][a-zA-Z0-9.\-_]*$/
+        $args{prefix} =~ /^[a-zA-Z_][a-zA-Z0-9.\-_]*$/
             or croak "a namespace prefix should look like [a-z_][a-z0-9.\\-_]*";
     }
 

--- a/t/2.0-modules.t
+++ b/t/2.0-modules.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 use strict;
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 use XML::RSS::LibXML;
 
 {
@@ -30,6 +30,18 @@ use XML::RSS::LibXML;
     # TEST
     like ($@, qr{\Aa namespace prefix should look like},
         "Testing for invalidty of / as a prefix char");
+}
+
+{
+    my $rss = XML::RSS::LibXML->new( version => '2.0' );
+    eval {
+        $rss->add_module(
+            prefix => 'Foobar',
+            uri => 'http://foobar.tld/foo/'
+        );
+    };
+    # TEST
+    ok !$@, "Testing for validity of ucfirst prefix";
 }
 
 {


### PR DESCRIPTION
XML::RSS::LibXML 0.3101 throws an exception when parsing a well-formed document that uses a namespace prefix beginning with an uppercase letter.

This patch adds a test for that case, and tweaks the relevant regex appropriately.
