### PR TITLE
Reset 'each' hash iterator

### DIFF
--- a/lib/XML/RSS/LibXML.pm
+++ b/lib/XML/RSS/LibXML.pm
@@ -227,6 +227,8 @@ sub guess_version_from_dom
         $root->setNamespace(NS_RSS10, $rss10_prefix, 0);
     }
 
+    keys %{$namespaces}; # reset iterator
+
     my $xc  = $self->create_xpath_context(
         # use the minimum required to guess
         $namespaces


### PR DESCRIPTION
No one knows which namespace is passed to 'registerNs' method,
because 'each' is called again in 'create_xpath_context' without resetting
'each' hash iterator.

And result of 'each' on hash after insertion without resetting hash
iterator is undefined from Perl 5.18.

Please see this patch.
